### PR TITLE
[BugFix] Issue #356

### DIFF
--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -80,8 +80,6 @@ export class Tour extends Evented {
       })(event);
     });
 
-    this.modal = new Modal(options);
-
     this._setTooltipDefaults();
     this._setTourID();
 
@@ -311,6 +309,7 @@ export class Tour extends Evented {
    * @private
    */
   _setupActiveTour() {
+    this.modal = new Modal(this.options);
     this._addBodyAttrs();
     this.trigger('active', { tour: this });
 


### PR DESCRIPTION
The _modalOverlayElem is destroyed upon cleanup, but is never rebuilt when restarting a tour.

Moved the creation of the modal from the constructor to the startup process of the tour. This way the modal is rebuilt for each run through the tour.